### PR TITLE
Epsg label typo

### DIFF
--- a/EGIS.Controls/CRSSelectionControl.Designer.cs
+++ b/EGIS.Controls/CRSSelectionControl.Designer.cs
@@ -92,7 +92,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(64, 13);
             this.label1.TabIndex = 3;
-            this.label1.Text = "EPGS Code";
+            this.label1.Text = "EPSG Code";
             // 
             // cbSelectedCRS
             // 

--- a/EGIS.Controls/SFMap.cs
+++ b/EGIS.Controls/SFMap.cs
@@ -280,10 +280,19 @@ namespace EGIS.Controls
 
         public class MapDoubleClickedEventArgs : EventArgs
         {
-            public MapDoubleClickedEventArgs()
+            public MapDoubleClickedEventArgs(MouseButtons button, int x, int y)
             {
+                Button = button;
+                X = x;
+                Y = y;
                 Cancel = false;
             }
+
+            public MouseButtons Button { get; set; }
+
+            public int X { get; set; }
+
+            public int Y { get; set; }
 
             /// <summary>
             /// get set whether to cancel the event. Set true to disable core zooming functinonality that occurs when
@@ -2251,7 +2260,7 @@ namespace EGIS.Controls
         {            
             base.OnDoubleClick(e);
 
-            MapDoubleClickedEventArgs mapDoubleClickEventArgs = new MapDoubleClickedEventArgs();
+            MapDoubleClickedEventArgs mapDoubleClickEventArgs = new MapDoubleClickedEventArgs(MouseDownButton, MouseDownPoint.X, MouseDownPoint.Y);
             this.OnMapDoubleClick(mapDoubleClickEventArgs);
             if(mapDoubleClickEventArgs.Cancel) return;
 


### PR DESCRIPTION
There is a typo on the CRSSelectionControl control the label text for label1 reads 'EPGS Code' and it should read 'EPSG Code'