### PR TITLE
Custom Render Direction

### DIFF
--- a/EGIS.ShapeFileLib/CustomRenderSettingsUtil.cs
+++ b/EGIS.ShapeFileLib/CustomRenderSettingsUtil.cs
@@ -220,6 +220,11 @@ namespace EGIS.ShapeFileLib
             return renderSettings.GetImageSymbol();
         }
 
+        public int GetDirection(int recordNumber)
+        {
+            return 0;
+        }
+
         #endregion
 
 
@@ -298,6 +303,11 @@ namespace EGIS.ShapeFileLib
             return null;
         }
 
+        public int GetDirection(int recordNumber)
+        {
+            return 0;
+        }
+
         #endregion
     }
 
@@ -343,6 +353,11 @@ namespace EGIS.ShapeFileLib
         public Image GetRecordImageSymbol(int recordNumber)
         {
             throw new Exception("The method or operation is not implemented.");
+        }
+
+        public int GetDirection(int recordNumber)
+        {
+            return 0;
         }
 
         #endregion
@@ -394,6 +409,11 @@ namespace EGIS.ShapeFileLib
         public Image GetRecordImageSymbol(int recordNumber)
         {
             throw new Exception("The method or operation is not implemented.");
+        }
+
+        public int GetDirection(int recordNumber)
+        {
+            return 0;
         }
 
         #endregion

--- a/EGIS.ShapeFileLib/ICustomRenderSettings.cs
+++ b/EGIS.ShapeFileLib/ICustomRenderSettings.cs
@@ -109,7 +109,9 @@ namespace EGIS.ShapeFileLib
         /// <returns></returns>
         System.Drawing.Image GetRecordImageSymbol(int recordNumber);
         
-
-
+        /// <summary>Gets the direction.</summary>
+        /// <param name="recordNumber">The record number.</param>
+        /// <returns><c>1</c> for forward direction; <c>-1</c> for reverse direction; <c>0</c> to suppress direction marker</returns>
+        int GetDirection(int recordNumber);
     }
 }

--- a/EGIS.ShapeFileLib/ShapeFile.cs
+++ b/EGIS.ShapeFileLib/ShapeFile.cs
@@ -8363,9 +8363,20 @@ namespace EGIS.ShapeFileLib
                                                     }
                                                 }
 												if (drawArrows && paintCount == (maxPaintCount-1))
-												{
-													DrawDirectionArrows(pointList, arrowLength, arrowPen, g);
-												}
+                                                {
+                                                    if (useCustomRenderSettings)
+                                                    {
+                                                        int len = arrowLength * customRenderSettings.GetDirection(index);
+                                                        if (len != 0)
+                                                        {
+                                                            DrawDirectionArrows(pointList, len, arrowPen, g);
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        DrawDirectionArrows(pointList, arrowLength, arrowPen, g);
+                                                    }
+                                                }
                                             }
                                         }
                                     }                                   
@@ -9580,7 +9591,18 @@ namespace EGIS.ShapeFileLib
 
 											if (drawArrows && paintCount == (maxPaintCount - 1))
 											{
-												DrawDirectionArrows(pointList, arrowLength, arrowPen, g);
+                                                if (useCustomRenderSettings)
+                                                {
+                                                    int len = arrowLength * customRenderSettings.GetDirection(index);
+                                                    if (len != 0)
+                                                    {
+                                                        DrawDirectionArrows(pointList, len, arrowPen, g);
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    DrawDirectionArrows(pointList, arrowLength, arrowPen, g);
+                                                }
 											}
 										}
                                     }
@@ -11835,9 +11857,20 @@ namespace EGIS.ShapeFileLib
 												}
 
 												if (drawArrows && paintCount == (maxPaintCount - 1))
-												{
-													DrawDirectionArrows(pointList, arrowLength, arrowPen, g);
-												}
+                                                {
+                                                    if (useCustomRenderSettings)
+                                                    {
+                                                        int len = arrowLength * customRenderSettings.GetDirection(index);
+                                                        if (len != 0)
+                                                        {
+                                                            DrawDirectionArrows(pointList, len, arrowPen, g);
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        DrawDirectionArrows(pointList, arrowLength, arrowPen, g);
+                                                    }
+                                                }
 
 											}
                                         }

--- a/EGIS.ShapeFileLib/TestCustomRenderSettings.cs
+++ b/EGIS.ShapeFileLib/TestCustomRenderSettings.cs
@@ -162,6 +162,11 @@ namespace EGIS.ShapeFileLib
             return this.renderSettings.GetImageSymbol();
         }
 
+        public int GetDirection(int recordNumber)
+        {
+            return 0;
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Add ability to override direction indication of the direction arrows based on a per line basis using custom render settings.

This allows direction of travel to be indicated rather than direction of drawing.

This is related to issue #7 