### PR TITLE
Update SFMap.cs

### DIFF
--- a/EGIS.Controls/SFMap.cs
+++ b/EGIS.Controls/SFMap.cs
@@ -432,7 +432,7 @@ namespace EGIS.Controls
             writer.WriteStartElement("layers");
 
             var layers = ShapeFilesLayers;
-            foreach (EGIS.ShapeFileLib.ShapeFile sf in layers)
+            foreach (EGIS.ShapeFileLib.ShapeFile sf in layers.ToArray())
             {
                 sf.WriteXml(writer);
             }
@@ -958,7 +958,7 @@ namespace EGIS.Controls
             RectangleD extent = RectangleD.Empty;
             bool extentSet = false;
             var layers = ShapeFilesLayers;
-            foreach (ShapeFile layer in layers)
+            foreach (ShapeFile layer in layers.ToArray())
             {
                 System.Collections.ObjectModel.ReadOnlyCollection<int> selectedIndicies = layer.SelectedRecordIndices;
                 if (selectedIndicies.Count > 0)
@@ -1105,7 +1105,7 @@ namespace EGIS.Controls
                     }
                     //RectangleD r2 = ShapeFile.ConvertExtent(r, this.MapCoordinateReferenceSystem, myShapefiles[0].CoordinateReferenceSystem);
 
-                    foreach (EGIS.ShapeFileLib.ShapeFile sf in layers)
+                    foreach (EGIS.ShapeFileLib.ShapeFile sf in layers.ToArray())
                     {
                         var extent = sf.Extent.Transform(sf.CoordinateReferenceSystem, this.MapCoordinateReferenceSystem);
                         if (double.IsInfinity(extent.Width) || double.IsInfinity(extent.Height))
@@ -1716,7 +1716,7 @@ namespace EGIS.Controls
                             m.Translate(-CropBorder/2, -CropBorder/2);
                             g2.Transform = m;
                             var layers = this.BackgroundShapeFiles;
-                            foreach (EGIS.ShapeFileLib.ShapeFile sf in layers)
+                            foreach (EGIS.ShapeFileLib.ShapeFile sf in layers.ToArray())
                             {
                                 //this is an expensive operation
                                 //using (ICoordinateTransformation coordinateTransformation = EGIS.Projections.CoordinateReferenceSystemFactory.Default.CreateCoordinateTrasformation(sf.CoordinateReferenceSystem, MapCoordinateReferenceSystem))
@@ -1746,7 +1746,7 @@ namespace EGIS.Controls
                             m.Translate(-CropBorder/2, -CropBorder/2);
                             g2.Transform = m;
                             var layers = this.ForegroundShapeFiles;
-                            foreach (EGIS.ShapeFileLib.ShapeFile sf in layers)
+                            foreach (EGIS.ShapeFileLib.ShapeFile sf in layers.ToArray())
                             {
                                 sf.Render(g2, renderSize, this._centrePoint, this._zoomLevel, this.projectionType, this.MapCoordinateReferenceSystem);
                             }
@@ -2652,7 +2652,7 @@ namespace EGIS.Controls
         {
             if (oldCrs == null || newCrs == null || this.ShapeFileCount == 0) return;
             List<ShapeFile> layers = this.ShapeFilesLayers;
-            foreach (ShapeFile layer in layers)
+            foreach (ShapeFile layer in layers.ToArray())
             {
                 RenderSettings.UpdateRenderSettings(layer.RenderSettings, sourceCenterPt, oldCrs, newCrs);
             }


### PR DESCRIPTION
About this issue: https://github.com/wfletcher/EasyGIS.NET/issues/71


Hi Winston.
My app do modifications on map through threads. Many times the map show the big red X because this error:

    Message: Collection was modified; enumeration operation may not execute.
    Message (StackTrace): at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
    at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
    at EGIS.Controls.SFMap.RenderShapefiles() in C:....\EGIS.Controls\SFMap.cs:line 1720
    at EGIS.Controls.SFMap.OnPaint(PaintEventArgs e) in C:....\EGIS.Controls\SFMap.cs:line 1838
    at System.Windows.Forms.Control.PaintWithErrorHandling(PaintEventArgs e, Int16 layer)
    at System.Windows.Forms.Control.WmPaint(Message& m)
    at System.Windows.Forms.Control.WndProc(Message& m)
    at System.Windows.Forms.UserControl.WndProc(Message& m)
    at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)

To solve this, on SFMap.cs I changed all foreach statements with layers collection to convert to array, like this:

    foreach (ShapeFile sf in layers.ToArray()) { ... }

By this way the iteration is through a copy of list. The error stopped.

I think that's a good thing to change on the project.