### PR TITLE
WinForms Designer error: “Constructor on type ‘EGIS.Controls.SFMap’ not found”

### DIFF
--- a/EGIS.Controls/SFMap.cs
+++ b/EGIS.Controls/SFMap.cs
@@ -474,6 +474,15 @@ namespace EGIS.Controls
         #endregion
 
         /// <summary>
+        /// Initializes a new <see cref="SFMap"/> control with the default settings
+        /// (WGS-84 CRS, zoom level 1 : 1, default mouse-wheel zoom mode).  
+        /// This parameter-less constructor exists primarily for the WinForms
+        /// designer, and delegates to the main constructor.
+        /// </summary>
+        public SFMap() : this(EGIS.Projections.CoordinateReferenceSystemFactory.Wgs84EpsgCode)
+        { }
+
+        /// <summary>
         /// SFMap contructor
         /// </summary>
         public SFMap(int CRSById = EGIS.Projections.CoordinateReferenceSystemFactory.Wgs84EpsgCode)


### PR DESCRIPTION
When Visual Studio loads a form in the WinForms Designer it uses reflection to create each control with
Activator.CreateInstance(controlType), which requires a public, parameter-less constructor.
EGIS.Controls.SFMap expose only the constructor that takes a CRS ID, so the designer fails with the message above and the form does not open.

**Work-around / permanent fix**
Add a parameter-less constructor that simply chains to the main one, keeping all initialization in a single place:

```csharp
public class SFMap : Control
{
    /// <summary>
    /// Initializes a new <see cref="SFMap"/> with the default WGS-84
    /// coordinate reference system.  
    /// Required by the WinForms Designer.
    /// </summary>
    public SFMap() : this(
        EGIS.Projections.CoordinateReferenceSystemFactory.Wgs84EpsgCode)
    {
        // intentionally left blank – all logic in the other ctor
    }

    /// <summary>
    /// Full constructor used at runtime.
    /// </summary>
    public SFMap(int crsById = EGIS.Projections.CoordinateReferenceSystemFactory.Wgs84EpsgCode)
    {
        InitializeComponent();
        // …regular initialization…
    }
}
```

- No extra object allocation occurs; the parameter-less ctor delegates to the real one.
- The control now opens in the designer without errors, and runtime behavior is unchanged.
